### PR TITLE
Compare Names Optimalization

### DIFF
--- a/src/main/java/org/protege/owl/diff/align/util/CompareNames.java
+++ b/src/main/java/org/protege/owl/diff/align/util/CompareNames.java
@@ -38,7 +38,7 @@ public class CompareNames {
 	}
 
 	private static String removeCharacter(String s, char c) {
-		String result = new String();
+		String result = "";
 		int currentIndex = 0;
 		int searchIndex;
 


### PR DESCRIPTION
FindBugs found a performance issue with this, namely that making a new string as such:
String result = new String() 
Takes up unnecessary memory, so instead I used the basic empty String : ""
Which is guaranteed to be the same, but doesn't take up memory each time the procedure is called.